### PR TITLE
Fix the comparison operator - 'gte' doesn't exist anymore

### DIFF
--- a/library/Zend/Xml/Security.php
+++ b/library/Zend/Xml/Security.php
@@ -169,7 +169,7 @@ class Zend_Xml_Security
         $isVulnerableVersion = (
             version_compare(PHP_VERSION, '5.5.22', 'lt')
             || (
-                version_compare(PHP_VERSION, '5.6', 'gte')
+                version_compare(PHP_VERSION, '5.6', '>=')
                 && version_compare(PHP_VERSION, '5.6.6', 'lt')
             )
         );


### PR DESCRIPTION
Zend Framework 1 reaches its End of Life (EOL) and is no longer maintained.
No Pull Requests will be accepted.

https://framework.zend.com/blog/2016-06-28-zf1-eol.html
