### PR TITLE
Add return type to getIterator

### DIFF
--- a/library/Zend/Db/Statement/Pdo.php
+++ b/library/Zend/Db/Statement/Pdo.php
@@ -263,7 +263,7 @@ class Zend_Db_Statement_Pdo extends Zend_Db_Statement implements IteratorAggrega
      *
      * @return IteratorIterator
      */
-    public function getIterator()
+    public function getIterator(): IteratorIterator
     {
         return new IteratorIterator($this->_stmt);
     }


### PR DESCRIPTION
Zend Framework 1 reaches its End of Life (EOL) and is no longer maintained.
No Pull Requests will be accepted.

https://framework.zend.com/blog/2016-06-28-zf1-eol.html
